### PR TITLE
Fix package.php.yml Mac OS jdk download url

### DIFF
--- a/package.php.yml
+++ b/package.php.yml
@@ -33,7 +33,7 @@ jdk:
     url: 'https://download.bell-sw.com/java/11/bellsoft-jdk11-windows-amd64.zip'
     dir: 'jdk-11'
   darwin:
-    url: 'https://download.bell-sw.com/java/11/bellsoft-jdk11-macos-amd64.zip'
+    url: 'https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-macos-amd64.zip'
     dir: 'jdk-11.jdk'
   linux:
     url: 'https://download.bell-sw.com/java/11/bellsoft-jdk11-linux-amd64.tar.gz'


### PR DESCRIPTION
Tried building the IDE on Mac OS, got errors like that:
```
Download JDK for darwin from https://download.bell-sw.com/java/11/bellsoft-jdk11-macos-amd64.zip

Fatal error: Uncaught exception 'php\io\IOException' with message 'File './tools/build/jre/bellsoft-jdk11-macos-amd64.zip' not found' in ./package.build.php on line 164, position 11
```
Updated macos download url (others are fine).